### PR TITLE
feat: Apply dark theme to index.html for site consistency

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,18 +1,18 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 /* General Body Styles */
 body {
-    font-family: 'Poppins', sans-serif;
+    font-family: 'Inter', sans-serif;
     margin: 0;
     padding: 0;
-    background-color: #f8f9fa; /* Lighter background */
-    color: #343a40; /* Darker text for better contrast */
+    background-color: #0f172a; /* slate-900 */
+    color: #cbd5e1; /* slate-300 */
     line-height: 1.7;
 }
 
 /* Header Styles */
 header {
-    background: linear-gradient(90deg, #56ab2f, #a8e063); /* Modern gradient */
+    background: linear-gradient(90deg, #be185d, #f97316); /* pink-600 to orange-500 */
     color: #ffffff;
     padding: 2.5rem 1rem;
     text-align: center;
@@ -28,7 +28,7 @@ header h1 {
 header p {
     margin: 0.5rem 0 0;
     font-size: 1.3rem; /* Slightly larger */
-    color: #e9ecef; /* Lighter subtitle */
+    color: #f1f5f9; /* slate-100 */
     font-weight: 300;
 }
 
@@ -48,9 +48,9 @@ main {
 
 /* Game Card Styles */
 .game-card {
-    background-color: #ffffff;
+    background-color: #1e293b; /* slate-800 */
     border-radius: 12px; /* More rounded corners */
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08); /* Softer, more diffused shadow */
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(255, 255, 255, 0.05);
     padding: 2rem; /* Increased padding */
     display: flex;
     flex-direction: column;
@@ -61,20 +61,20 @@ main {
 
 .game-card:hover {
     transform: translateY(-8px); /* More pronounced hover effect */
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12); /* Enhanced shadow on hover */
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .game-card h2 {
     margin-top: 1rem;
     margin-bottom: 0.75rem; /* Adjusted margin */
-    color: #2c3e50; /* Kept color, good contrast */
+    color: #e2e8f0; /* slate-200 */
     font-size: 1.9rem; /* Slightly larger */
     font-weight: 600;
 }
 
 .game-card p {
     font-size: 1rem;
-    color: #555e68; /* Slightly softer text color */
+    color: #94a3b8; /* slate-400 */
     margin-bottom: 1.5rem;
     flex-grow: 1;
 }
@@ -82,13 +82,13 @@ main {
 .game-preview {
     width: 80px;
     height: 80px;
-    background-color: #e9ecef; /* Lighter preview background */
+    background-color: #334155; /* slate-700 */
     border-radius: 12px; /* Match card rounding */
     display: flex;
     justify-content: center;
     align-items: center;
     margin-bottom: 1.5rem; /* Increased margin */
-    color: #56ab2f; /* Icon color to match new primary */
+    color: #22d3ee; /* cyan-400 */
 }
 
 .game-preview svg {
@@ -100,7 +100,7 @@ main {
 /* Play Button Styles */
 .play-button {
     display: inline-block;
-    background-color: #56ab2f; /* New primary color */
+    background-color: #0ea5e9; /* sky-500 */
     color: #ffffff;
     padding: 0.85rem 1.8rem; /* Slightly larger padding */
     text-decoration: none;
@@ -112,7 +112,7 @@ main {
 }
 
 .play-button:hover {
-    background-color: #4a9326; /* Darker shade for hover */
+    background-color: #0284c7; /* sky-600 */
     transform: translateY(-2px); /* Slight lift on hover */
 }
 
@@ -120,7 +120,7 @@ main {
 footer {
     text-align: center;
     padding: 2rem 1rem; /* Increased padding */
-    background-color: #343a40; /* Darker footer */
+    background-color: #1e293b; /* slate-800 - to match cards */
     color: #f8f9fa; /* Light text on dark background */
     margin-top: 3rem; /* Increased margin */
 }


### PR DESCRIPTION
This commit updates style.css to apply a dark, modern theme to the main game selection page (index.html), aligning its visual appearance with the individual game pages.

Key changes in style.css include:
- Changed the primary font from 'Poppins' to 'Inter' and updated the Google Fonts import URL.
- Body background set to a dark slate color (slate-900) with light default text.
- Header background updated from a light green gradient to a vibrant pink-to-orange gradient, with adjusted subtitle text color for contrast.
- Game card styles (.game-card) now use a dark background (slate-800), with updated text colors and shadows suitable for a dark theme.
- Game preview icon container (.game-preview) background and icon colors updated to fit the dark theme.
- Play button (.play-button) styles changed to use colors (sky-500) consistent with buttons on individual game pages.
- Footer background updated to a darker shade (slate-800) to match card backgrounds.

No direct changes to index.html were needed for the font, as style.css handles the import and application of the 'Inter' font.

These changes ensure a more uniform and modern look and feel across the entire Tic Tac Pro website.