### PR TITLE
Fix broken 3D Pro page

### DIFF
--- a/tic-tac-3d-pro.html
+++ b/tic-tac-3d-pro.html
@@ -5,8 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tic Tac Toe 3D Pro</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/controls/OrbitControls.js"></script>
+    <!-- Using a Three.js version that still provides UMD builds for the examples -->
+    <script src="https://cdn.jsdelivr.net/npm/three@0.130.1/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.130.1/examples/js/controls/OrbitControls.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- point 3D Pro to a Three.js version that still includes OrbitControls in the UMD format

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448e61c3ac8327aae81c1c241d5443