### PR TITLE
Fix likes when offline

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,16 +238,41 @@
     document.querySelectorAll(".like-button").forEach(btn => {
         const key = btn.dataset.key;
         const countSpan = btn.querySelector(".like-count");
+        const localKey = `likes-${key}`;
+        let localCount = parseInt(localStorage.getItem(localKey) || '0');
+
+        function render(count) {
+            countSpan.textContent = count;
+        }
+
         function update() {
             fetch(`https://api.countapi.xyz/get/tictacpro/${key}`)
                 .then(r => r.json())
-                .then(d => countSpan.textContent = d.value);
+                .then(d => {
+                    localCount = d.value;
+                    localStorage.setItem(localKey, localCount);
+                    render(localCount);
+                })
+                .catch(() => {
+                    render(localCount);
+                });
         }
+
         btn.addEventListener("click", () => {
             fetch(`https://api.countapi.xyz/hit/tictacpro/${key}`)
                 .then(r => r.json())
-                .then(d => countSpan.textContent = d.value);
+                .then(d => {
+                    localCount = d.value;
+                    localStorage.setItem(localKey, localCount);
+                    render(localCount);
+                })
+                .catch(() => {
+                    localCount++;
+                    localStorage.setItem(localKey, localCount);
+                    render(localCount);
+                });
         });
+
         update();
     });
     </script>


### PR DESCRIPTION
## Summary
- fallback to localStorage for like buttons when `countapi` fails
- update displayed like counts accordingly

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68448f366c2c8327a083b8e43118c70e