### PR TITLE
Fix 3D Pro page module imports

### DIFF
--- a/tic-tac-3d-pro.html
+++ b/tic-tac-3d-pro.html
@@ -29,8 +29,15 @@
         </div>
     </div>
 
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js"
+  }
+}
+</script>
 <script type="module">
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js';
+import * as THREE from 'three';
 import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.152.2/examples/jsm/controls/OrbitControls.js';
 let scene, camera, renderer, controls, raycaster, mouse;
 const board = Array(27).fill('');


### PR DESCRIPTION
## Summary
- load `three.js` using an import map so OrbitControls resolves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685347597b5c832794a97262254676b0