### PR TITLE
Add Tic Tac Orbit variant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,4 @@ We are building a portfolio-worthy collection that demonstrates:
 - 2025-08-27 ChatGPT: Implemented Tic Tac Wind variant with gusting rows and updated variant lists.
 - 2025-11-21 ChatGPT: Implemented Tic Tac Eclipse variant, updated index, and refreshed variant lists.
 - 2025-12-08 Antigravity: Refactored agent documentation into multiple files for better scalability and clarity.
+- 2025-12-10 ChatGPT: Implemented Tic Tac Orbit variant and updated variant listings.

--- a/AGENTS_IDEAS.md
+++ b/AGENTS_IDEAS.md
@@ -6,7 +6,6 @@ Agents: Maintain this list. When you complete a variant, move it to the "Existin
 
 ### Proposed Variants (Ready to Build)
 
-*   **Tic Tac Orbit**: Edge moves pull the nearest corner one space clockwise.
 *   **Tic Tac Chaos**: The board size changes randomly (3x3 to 4x4) during the game.
 *   **Tic Tac Stealth**: Opponent's moves are invisible for 1 turn.
 *   **Multiplayer Websockets**: (Future Goal) Real-time P2P play.
@@ -52,3 +51,4 @@ Agents: Maintain this list. When you complete a variant, move it to the "Existin
 *   Tic Tac Freeze
 *   Tic Tac Time
 *   Tic Tac Portal
+*   Tic Tac Orbit

--- a/index.html
+++ b/index.html
@@ -440,6 +440,18 @@
                 <p>Playing in a corner teleports your mark to the opposite corner.</p>
                 <a href="tic-tac-portal.html" class="play-button">Play Tic Tac Portal</a>
             </div>
+            <div class="game-card">
+                <div class="game-preview classic-preview">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="9"></circle>
+                        <path d="M12 7v5l4 2"></path>
+                        <polyline points="5 12 7 10 7 14"></polyline>
+                    </svg>
+                </div>
+                <h2>Tic Tac Orbit</h2>
+                <p>Edge moves pull the nearest corner one space clockwise, rotating threats across the grid.</p>
+                <a href="tic-tac-orbit.html" class="play-button">Play Tic Tac Orbit</a>
+            </div>
 
         </section>
     </main>

--- a/tic-tac-orbit.html
+++ b/tic-tac-orbit.html
@@ -1,0 +1,535 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tic Tac Orbit</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+            touch-action: manipulation;
+            /* Prevents double-tap zoom on mobile */
+        }
+
+        .cell {
+            width: 100px;
+            height: 100px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 3rem;
+            font-weight: bold;
+            cursor: pointer;
+            border: 2px solid #374151;
+            /* gray-700 - Cell's own border */
+            background-color: #1e293b;
+            /* slate-800 - Cell background to match container */
+            transition: background-color 0.3s ease;
+        }
+
+        .cell:hover {
+            background-color: #334155;
+            /* slate-700 - Lighter for hover */
+        }
+
+        .cell.x {
+            color: #22d3ee;
+            /* cyan-400 */
+        }
+
+        .cell.o {
+            color: #f472b6;
+            /* pink-400 */
+        }
+
+        /* Responsive adjustments */
+        @media (max-width: 600px) {
+            .cell {
+                width: 80px;
+                height: 80px;
+                font-size: 2.5rem;
+            }
+
+            .status {
+                font-size: 1.125rem;
+                /* text-lg */
+            }
+
+            .mode-button,
+            .reset-button {
+                padding: 0.5rem 1rem;
+                /* py-2 px-4 */
+                font-size: 0.875rem;
+                /* text-sm */
+            }
+        }
+
+        @media (max-width: 400px) {
+            .cell {
+                width: 70px;
+                height: 70px;
+                font-size: 2rem;
+            }
+
+            .status {
+                font-size: 1rem;
+                /* text-base */
+            }
+        }
+
+        /* Modal styles */
+        .modal {
+            display: none;
+            /* Hidden by default */
+            position: fixed;
+            z-index: 1000;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            overflow: auto;
+            background-color: rgba(0, 0, 0, 0.5);
+            align-items: center;
+            justify-content: center;
+        }
+
+        .modal-content {
+            background-color: #ffffff;
+            margin: auto;
+            padding: 20px;
+            border-radius: 8px;
+            text-align: center;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+
+        .modal-button {
+            margin-top: 15px;
+            padding: 10px 20px;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+    </style>
+</head>
+
+<body
+    class="bg-gradient-to-br from-slate-900 to-slate-700 text-white min-h-screen flex flex-col items-center justify-center p-4">
+
+    <div class="bg-slate-800 p-6 md:p-8 rounded-xl shadow-2xl w-full max-w-md">
+        <h1
+            class="text-4xl md:text-5xl font-bold text-center mb-6 bg-clip-text text-transparent bg-gradient-to-r from-pink-500 via-red-500 to-yellow-500">
+            Tic Tac Orbit</h1>
+        <p class="text-slate-300 text-sm sm:text-base my-4 text-center max-w-xs sm:max-w-sm mx-auto leading-relaxed">
+            Edge moves shift the nearest corner one space clockwise, pulling the orbiting mark around the board. Time
+            your edge plays to rotate threats into winning lines.
+        </p>
+        <div class="bg-slate-900/70 border border-slate-700 rounded-lg p-3 text-xs sm:text-sm text-slate-300 mb-5">
+            <p class="font-semibold text-slate-200">Orbit Rule</p>
+            <p>Place on an edge and the closest clockwise corner slides one space clockwise if that edge is open.</p>
+        </div>
+        <div id="modeSelection" class="mb-6 text-center">
+            <h2 class="text-xl mb-3 text-slate-300">Choose Game Mode:</h2>
+            <div class="flex justify-center space-x-3">
+                <button id="vsPlayer"
+                    class="mode-button bg-sky-500 hover:bg-sky-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105">2
+                    Players</button>
+                <button id="vsComputer"
+                    class="mode-button bg-emerald-500 hover:bg-emerald-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105">vs
+                    Computer</button>
+            </div>
+        </div>
+
+        <div id="gameArea" class="hidden">
+            <div id="gameBoard"
+                class="grid grid-cols-3 gap-1.5 mx-auto bg-slate-500 rounded-lg overflow-hidden shadow-lg"
+                style="width: fit-content;">
+            </div>
+
+            <p id="status" class="status text-xl text-center mt-6 mb-4 h-8 text-slate-300"></p>
+
+            <div class="flex justify-center space-x-3 mt-4">
+                <button id="resetButton"
+                    class="reset-button bg-rose-500 hover:bg-rose-600 text-white font-semibold py-2 px-6 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105">Reset
+                    Game</button>
+                <button id="changeModeButton"
+                    class="reset-button bg-amber-500 hover:bg-amber-600 text-white font-semibold py-2 px-6 rounded-lg shadow-md transition duration-150 ease-in-out transform hover:scale-105">Change
+                    Mode</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="messageModal" class="modal">
+        <div class="modal-content bg-slate-800 text-white p-6 rounded-lg shadow-xl max-w-sm mx-auto">
+            <p id="modalMessage" class="text-lg mb-4"></p>
+            <button id="modalCloseButton"
+                class="modal-button bg-indigo-500 hover:bg-indigo-600 text-white font-semibold py-2 px-5 rounded-md">OK</button>
+        </div>
+    </div>
+
+    <script>
+        // DOM Elements
+        const gameBoardElement = document.getElementById('gameBoard');
+        const statusElement = document.getElementById('status');
+        const resetButton = document.getElementById('resetButton');
+        const changeModeButton = document.getElementById('changeModeButton');
+        const modeSelectionDiv = document.getElementById('modeSelection');
+        const gameAreaDiv = document.getElementById('gameArea');
+        const vsPlayerButton = document.getElementById('vsPlayer');
+        const vsComputerButton = document.getElementById('vsComputer');
+
+        // Modal elements
+        const messageModal = document.getElementById('messageModal');
+        const modalMessageElement = document.getElementById('modalMessage');
+        const modalCloseButton = document.getElementById('modalCloseButton');
+
+        // Game State Variables
+        let board = ['', '', '', '', '', '', '', '', ''];
+        let currentPlayer = 'X';
+        let gameActive = true;
+        let gameMode = ''; // '2P' or 'PvC'
+        let computerTimeout;
+
+        const winningConditions = [
+            [0, 1, 2], [3, 4, 5], [6, 7, 8], // Rows
+            [0, 3, 6], [1, 4, 7], [2, 5, 8], // Columns
+            [0, 4, 8], [2, 4, 6]             // Diagonals
+        ];
+
+        const orbitShiftMap = {
+            1: { corner: 2, target: 5 }, // Top edge pulls top-right corner down
+            5: { corner: 8, target: 7 }, // Right edge pulls bottom-right corner left
+            7: { corner: 6, target: 3 }, // Bottom edge pulls bottom-left corner up
+            3: { corner: 0, target: 1 }  // Left edge pulls top-left corner right
+        };
+
+        // --- Modal Functions ---
+        function showModal(message) {
+            modalMessageElement.textContent = message;
+            messageModal.style.display = 'flex';
+        }
+
+        function closeModal() {
+            messageModal.style.display = 'none';
+        }
+
+        modalCloseButton.addEventListener('click', closeModal);
+        // Close modal if user clicks outside of it
+        window.addEventListener('click', (event) => {
+            if (event.target === messageModal) {
+                closeModal();
+            }
+        });
+
+
+        // --- Game Logic Functions ---
+
+        // Function to initialize or reset the game
+        function initializeGame() {
+            board = ['', '', '', '', '', '', '', '', ''];
+            // currentPlayer = 'X'; // Current player is set when mode is chosen or game is reset
+            gameActive = true;
+            statusElement.textContent = `${gameMode === 'PvC' && currentPlayer === 'O' ? "Computer's (O)" : `Player ${currentPlayer}'s`} turn`;
+            renderBoard(); // This will now add event listeners correctly after clearing
+            clearTimeout(computerTimeout);
+
+            if (gameMode === 'PvC' && currentPlayer === 'O') {
+                statusElement.textContent = "Computer's (O) thinking...";
+                toggleBoardInteraction(false);
+                computerTimeout = setTimeout(() => {
+                    computerMove();
+                    toggleBoardInteraction(true);
+                }, 700);
+            }
+        }
+
+        // Function to render the board on the UI
+        function renderBoard() {
+            gameBoardElement.innerHTML = ''; // Clear existing board
+            board.forEach((mark, index) => {
+                const cell = document.createElement('div');
+                cell.classList.add('cell', 'rounded-md'); // Cells have their own background now
+                if (mark === 'X') cell.classList.add('x');
+                if (mark === 'O') cell.classList.add('o');
+                cell.textContent = mark;
+                cell.dataset.index = index;
+                cell.setAttribute('aria-label', `Cell ${index + 1}, currently ${mark || 'empty'}`);
+                cell.setAttribute('role', 'button');
+                cell.setAttribute('tabindex', '0');
+                // Add event listeners directly here after creation
+                cell.addEventListener('click', handleCellClick);
+                cell.addEventListener('touchend', handleCellClick, { passive: false }); // passive: false for preventDefault
+                gameBoardElement.appendChild(cell);
+            });
+        }
+
+        // Function to handle a cell click
+        function handleCellClick(event) {
+            event.preventDefault(); // Prevents issues with double tap zoom or other default behaviors
+            if (!gameActive) return;
+
+            const clickedCell = event.currentTarget; // Use currentTarget for dynamically added listeners
+            const clickedCellIndex = parseInt(clickedCell.dataset.index);
+
+            if (board[clickedCellIndex] !== '' || !gameActive) {
+                return; // Cell already played or game over
+            }
+
+            // Player's move
+            makeMove(clickedCellIndex, currentPlayer);
+
+            if (!gameActive) return; // Game ended after player's move
+
+            // If PvC mode and it's computer's turn
+            if (gameMode === 'PvC' && currentPlayer === 'O' && gameActive) {
+                statusElement.textContent = "Computer's (O) thinking...";
+                toggleBoardInteraction(false);
+                computerTimeout = setTimeout(() => {
+                    computerMove();
+                    toggleBoardInteraction(true);
+                }, 700);
+            }
+        }
+
+        // Function to make a move
+        function makeMove(index, player) {
+            if (board[index] === '' && gameActive) {
+                board[index] = player;
+                const cellElement = gameBoardElement.children[index];
+                cellElement.textContent = player;
+                if (player === 'X') cellElement.classList.add('x');
+                if (player === 'O') cellElement.classList.add('o');
+                cellElement.setAttribute('aria-label', `Cell ${index + 1}, marked as ${player}`);
+
+                applyOrbitShift(index);
+
+                const winner = checkWinner();
+                if (winner) {
+                    endGame(false, winner);
+                } else if (board.every(cell => cell !== '')) {
+                    endGame(true); // It's a tie
+                } else {
+                    switchPlayer();
+                }
+            }
+        }
+
+        // Function to switch player
+        function switchPlayer() {
+            currentPlayer = currentPlayer === 'X' ? 'O' : 'X';
+            if (gameActive) {
+                statusElement.textContent = `${gameMode === 'PvC' && currentPlayer === 'O' ? "Computer's (O)" : `Player ${currentPlayer}'s`} turn`;
+            }
+        }
+
+        // Function to check for a win
+        function checkWin(player) {
+            return winningConditions.some(condition => {
+                return condition.every(index => board[index] === player);
+            });
+        }
+
+        function checkWinner() {
+            if (checkWin(currentPlayer)) {
+                return currentPlayer;
+            }
+            const opponent = currentPlayer === 'X' ? 'O' : 'X';
+            if (checkWin(opponent)) {
+                return opponent;
+            }
+            return null;
+        }
+
+        function applyOrbitShift(index) {
+            if (!orbitShiftMap[index]) {
+                return;
+            }
+
+            const { corner, target } = orbitShiftMap[index];
+            if (board[corner] && board[target] === '') {
+                const movingMark = board[corner];
+                board[corner] = '';
+                board[target] = movingMark;
+                updateCellDisplay(corner);
+                updateCellDisplay(target);
+            }
+        }
+
+        function updateCellDisplay(index) {
+            const cellElement = gameBoardElement.children[index];
+            cellElement.classList.remove('x', 'o');
+            cellElement.textContent = board[index];
+            if (board[index] === 'X') cellElement.classList.add('x');
+            if (board[index] === 'O') cellElement.classList.add('o');
+            cellElement.setAttribute('aria-label', `Cell ${index + 1}, currently ${board[index] || 'empty'}`);
+        }
+
+        // Function for the computer's move (AI)
+        function computerMove() {
+            if (!gameActive) return;
+
+            let bestMove = -1;
+
+            // 1. Check if computer can win in the next move
+            for (let i = 0; i < board.length; i++) {
+                if (board[i] === '') {
+                    const simulatedBoard = getBoardAfterMove(i, 'O');
+                    if (checkWinForBoard(simulatedBoard, 'O')) {
+                        bestMove = i;
+                        break;
+                    }
+                }
+            }
+
+            // 2. Check if player can win in the next move, and block them
+            if (bestMove === -1) {
+                for (let i = 0; i < board.length; i++) {
+                    if (board[i] === '') {
+                        const simulatedBoard = getBoardAfterMove(i, 'X');
+                        if (checkWinForBoard(simulatedBoard, 'X')) {
+                            bestMove = i;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // 3. Try to take the center if available
+            if (bestMove === -1 && board[4] === '') {
+                bestMove = 4;
+            }
+
+            // 4. Try to take a corner if available
+            if (bestMove === -1) {
+                const corners = [0, 2, 6, 8];
+                const availableCorners = corners.filter(index => board[index] === '');
+                if (availableCorners.length > 0) {
+                    bestMove = availableCorners[Math.floor(Math.random() * availableCorners.length)];
+                }
+            }
+
+            // 5. Try to take a side if available (or any remaining spot)
+            if (bestMove === -1) {
+                const availableMoves = board.map((val, idx) => val === '' ? idx : null).filter(val => val !== null);
+                if (availableMoves.length > 0) {
+                    bestMove = availableMoves[Math.floor(Math.random() * availableMoves.length)];
+                }
+            }
+
+            if (bestMove !== -1) {
+                makeMove(bestMove, 'O');
+            } else if (board.every(cell => cell !== '')) {
+                endGame(true);
+            }
+        }
+
+        function getBoardAfterMove(index, player) {
+            const simulatedBoard = [...board];
+            simulatedBoard[index] = player;
+            applyOrbitShiftForBoard(simulatedBoard, index);
+            return simulatedBoard;
+        }
+
+        function checkWinForBoard(boardState, player) {
+            return winningConditions.some(condition => {
+                return condition.every(index => boardState[index] === player);
+            });
+        }
+
+        function applyOrbitShiftForBoard(boardState, index) {
+            if (!orbitShiftMap[index]) {
+                return;
+            }
+            const { corner, target } = orbitShiftMap[index];
+            if (boardState[corner] && boardState[target] === '') {
+                boardState[target] = boardState[corner];
+                boardState[corner] = '';
+            }
+        }
+
+        // Function to end the game
+        function endGame(isTie, winner = null) {
+            gameActive = false;
+            if (isTie) {
+                statusElement.textContent = "It's a Tie!";
+                showModal("It's a Tie! Well played by both sides.");
+            } else if (winner) {
+                const winnerName = (gameMode === 'PvC' && winner === 'O') ? "Computer (O)" : `Player ${winner}`;
+                statusElement.textContent = `${winnerName} wins!`;
+                showModal(`${winnerName} is the winner! Congratulations!`);
+
+                winningConditions.forEach(condition => {
+                    if (condition.every(index => board[index] === winner)) {
+                        condition.forEach(index => {
+                            gameBoardElement.children[index].classList.add('bg-yellow-400', 'text-slate-800');
+                        });
+                    }
+                });
+            }
+        }
+
+        function toggleBoardInteraction(enable) {
+            const cells = document.querySelectorAll('.cell');
+            cells.forEach(cell => {
+                if (enable) {
+                    cell.style.pointerEvents = 'auto';
+                    cell.style.opacity = '1';
+                } else {
+                    cell.style.pointerEvents = 'none';
+                    cell.style.opacity = '0.7';
+                }
+            });
+        }
+
+        // --- Event Listeners Setup ---
+        vsPlayerButton.addEventListener('click', () => {
+            gameMode = '2P';
+            currentPlayer = 'X'; // Player X starts in 2P mode
+            modeSelectionDiv.classList.add('hidden');
+            gameAreaDiv.classList.remove('hidden');
+            initializeGame();
+        });
+
+        vsComputerButton.addEventListener('click', () => {
+            gameMode = 'PvC';
+            modeSelectionDiv.classList.add('hidden');
+            gameAreaDiv.classList.remove('hidden');
+            currentPlayer = Math.random() < 0.5 ? 'X' : 'O'; // Randomly decide who starts
+            initializeGame();
+        });
+
+        resetButton.addEventListener('click', () => {
+            if (gameMode === 'PvC') {
+                currentPlayer = Math.random() < 0.5 ? 'X' : 'O';
+            } else {
+                currentPlayer = 'X';
+            }
+            initializeGame();
+        });
+
+        changeModeButton.addEventListener('click', () => {
+            gameAreaDiv.classList.add('hidden');
+            modeSelectionDiv.classList.remove('hidden');
+            statusElement.textContent = "";
+        });
+
+        gameBoardElement.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                const activeElement = document.activeElement;
+                if (activeElement && activeElement.classList.contains('cell')) {
+                    handleCellClick({ currentTarget: activeElement, preventDefault: () => { } });
+                }
+            }
+        });
+
+        // Initial setup
+        modeSelectionDiv.classList.remove('hidden');
+        gameAreaDiv.classList.add('hidden');
+
+    </script>
+    <div class="mt-6 text-center">
+        <a href="index.html" class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded">Return to Menu</a>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
### Motivation

- Introduce a new Tic Tac variant where edge placements shift nearby corners clockwise to create rotating strategic threats.
- Follow the repository workflow by adding a standalone HTML game page and integrating it into the main index and project documentation.

### Description

- Added `tic-tac-orbit.html` (copied from `tic-tac-classic.html`) with updated title, colors, a UI note about the orbit rule, and the orbit mechanics implemented in JavaScript.
- Implemented orbit logic via an `orbitShiftMap` and functions `applyOrbitShift`, `applyOrbitShiftForBoard`, `updateCellDisplay`, plus AI-aware simulation helpers `getBoardAfterMove` and `checkWinForBoard` so the computer accounts for orbit shifts when choosing moves.
- Updated `index.html` to add a game card for `tic-tac-orbit.html` and updated project lists in `AGENTS_IDEAS.md` and the log in `AGENTS.md`.

### Testing

- Launched a local HTTP server (`python -m http.server`) and used Playwright to load `http://127.0.0.1:8000/tic-tac-orbit.html` and capture a screenshot (`artifacts/tic-tac-orbit.png`), which completed successfully.
- No automated unit tests were added for this change since it is a static HTML/JS game page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658887a6f883279324c0080ca0a977)